### PR TITLE
Fix 'more than one device' errors from duplicate mDNS connections

### DIFF
--- a/src/adb_mcp/adb.py
+++ b/src/adb_mcp/adb.py
@@ -14,10 +14,27 @@ def _find_adb() -> str:
 
 ADB = _find_adb()
 
+_device_serial: str | None = None
+
+
+def set_device_serial(serial: str | None) -> None:
+    global _device_serial
+    _device_serial = serial
+
+
+def get_device_serial() -> str | None:
+    return _device_serial
+
+
+def _base_cmd() -> list[str]:
+    if _device_serial:
+        return [ADB, "-s", _device_serial]
+    return [ADB]
+
 
 def adb_exec(*args: str, timeout: float = 10) -> str:
     result = subprocess.run(
-        [ADB] + list(args),
+        _base_cmd() + list(args),
         capture_output=True,
         text=True,
         timeout=timeout,
@@ -29,7 +46,7 @@ def adb_exec(*args: str, timeout: float = 10) -> str:
 
 def adb_exec_binary(*args: str, timeout: float = 10) -> bytes:
     result = subprocess.run(
-        [ADB] + list(args),
+        _base_cmd() + list(args),
         capture_output=True,
         timeout=timeout,
     )

--- a/src/adb_mcp/tools/device.py
+++ b/src/adb_mcp/tools/device.py
@@ -1,4 +1,4 @@
-from adb_mcp.adb import adb_exec
+from adb_mcp.adb import adb_exec, set_device_serial
 from adb_mcp.discovery import discover_pairing_devices, discover_connect_devices
 
 
@@ -26,9 +26,23 @@ def device_pair(code: str, host: str | None = None, port: int | None = None) -> 
     return "\n".join(lines)
 
 
+def _deduplicate_devices(devices: list[dict]) -> list[dict]:
+    """Keep only one entry per unique IP address."""
+    seen: dict[str, dict] = {}
+    for d in devices:
+        host = d["host"]
+        if host not in seen:
+            seen[host] = d
+    return list(seen.values())
+
+
 def device_connect(host: str | None = None, port: int | None = None) -> str:
     if host:
-        return adb_exec("connect", f"{host}:{port or 5555}", timeout=15)
+        serial = f"{host}:{port or 5555}"
+        result = adb_exec("connect", serial, timeout=15)
+        if "connected" in result:
+            set_device_serial(serial)
+        return result
 
     devices = discover_connect_devices(timeout=5.0)
     if not devices:
@@ -37,10 +51,19 @@ def device_connect(host: str | None = None, port: int | None = None) -> str:
             "is enabled on your phone and it's on the same network."
         )
 
+    devices = _deduplicate_devices(devices)
+
     lines = []
+    connected_serial = None
     for d in devices:
-        result = adb_exec("connect", f"{d['host']}:{d['port']}", timeout=15)
-        lines.append(f"{d['name']} ({d['host']}:{d['port']}): {result}")
+        serial = f"{d['host']}:{d['port']}"
+        result = adb_exec("connect", serial, timeout=15)
+        if "connected" in result and connected_serial is None:
+            connected_serial = serial
+        lines.append(f"{d['name']} ({serial}): {result}")
+
+    if connected_serial:
+        set_device_serial(connected_serial)
 
     if len(lines) == 1:
         return lines[0]

--- a/tests/test_adb.py
+++ b/tests/test_adb.py
@@ -1,11 +1,14 @@
 from unittest.mock import patch, MagicMock
 import subprocess
 
-from adb_mcp.adb import adb_exec, adb_exec_binary
+from adb_mcp.adb import adb_exec, adb_exec_binary, set_device_serial
 
 
 @patch("adb_mcp.adb.ADB", "/usr/bin/adb")
 class TestAdbExec:
+    def setup_method(self):
+        set_device_serial(None)
+
     def test_returns_stdout_on_success(self):
         result = MagicMock(returncode=0, stdout="List of devices attached\n", stderr="")
         with patch("adb_mcp.adb.subprocess.run", return_value=result) as mock_run:
@@ -36,9 +39,22 @@ class TestAdbExec:
             except subprocess.TimeoutExpired:
                 pass
 
+    def test_includes_serial_when_set(self):
+        set_device_serial("192.168.1.10:40845")
+        result = MagicMock(returncode=0, stdout="ok", stderr="")
+        with patch("adb_mcp.adb.subprocess.run", return_value=result) as mock_run:
+            adb_exec("shell", "ls")
+            mock_run.assert_called_once_with(
+                ["/usr/bin/adb", "-s", "192.168.1.10:40845", "shell", "ls"],
+                capture_output=True, text=True, timeout=10,
+            )
+
 
 @patch("adb_mcp.adb.ADB", "/usr/bin/adb")
 class TestAdbExecBinary:
+    def setup_method(self):
+        set_device_serial(None)
+
     def test_returns_bytes_on_success(self):
         result = MagicMock(returncode=0, stdout=b"\x89PNG", stderr=b"")
         with patch("adb_mcp.adb.subprocess.run", return_value=result):
@@ -53,3 +69,13 @@ class TestAdbExecBinary:
                 assert False, "Should have raised"
             except RuntimeError as e:
                 assert "device not found" in str(e)
+
+    def test_includes_serial_when_set(self):
+        set_device_serial("192.168.1.10:40845")
+        result = MagicMock(returncode=0, stdout=b"\x89PNG", stderr=b"")
+        with patch("adb_mcp.adb.subprocess.run", return_value=result) as mock_run:
+            adb_exec_binary("exec-out", "screencap", "-p")
+            mock_run.assert_called_once_with(
+                ["/usr/bin/adb", "-s", "192.168.1.10:40845", "exec-out", "screencap", "-p"],
+                capture_output=True, timeout=10,
+            )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,8 +1,10 @@
 from unittest.mock import patch
 
+from adb_mcp.adb import set_device_serial, get_device_serial
 from adb_mcp.tools.input import _escape_text, press_key
 from adb_mcp.tools.app import launch_app
 from adb_mcp.tools.logs import read_logs
+from adb_mcp.tools.device import device_connect, _deduplicate_devices
 
 
 class TestEscapeText:
@@ -72,3 +74,51 @@ class TestReadLogs:
         read_logs(lines=100)
         args = mock_exec.call_args[0]
         assert "100" in args
+
+
+class TestDeduplicateDevices:
+    def test_removes_duplicate_ips(self):
+        devices = [
+            {"name": "device-a", "host": "192.168.1.10", "port": 40845},
+            {"name": "device-b", "host": "192.168.1.10", "port": 40846},
+        ]
+        result = _deduplicate_devices(devices)
+        assert len(result) == 1
+        assert result[0]["name"] == "device-a"
+
+    def test_keeps_different_ips(self):
+        devices = [
+            {"name": "phone", "host": "192.168.1.10", "port": 40845},
+            {"name": "tablet", "host": "192.168.1.11", "port": 40845},
+        ]
+        result = _deduplicate_devices(devices)
+        assert len(result) == 2
+
+    def test_empty_list(self):
+        assert _deduplicate_devices([]) == []
+
+
+class TestDeviceConnect:
+    def setup_method(self):
+        set_device_serial(None)
+
+    @patch("adb_mcp.tools.device.adb_exec", return_value="connected to 192.168.1.10:5555")
+    def test_manual_host_sets_serial(self, mock_exec):
+        device_connect(host="192.168.1.10", port=5555)
+        assert get_device_serial() == "192.168.1.10:5555"
+
+    @patch("adb_mcp.tools.device.adb_exec", return_value="connected to 192.168.1.10:40845")
+    @patch("adb_mcp.tools.device.discover_connect_devices", return_value=[
+        {"name": "device-a", "host": "192.168.1.10", "port": 40845},
+        {"name": "device-b", "host": "192.168.1.10", "port": 40846},
+    ])
+    def test_auto_deduplicates_and_sets_serial(self, mock_discover, mock_exec):
+        result = device_connect()
+        # Should only connect once (deduplicated)
+        mock_exec.assert_called_once()
+        assert get_device_serial() == "192.168.1.10:40845"
+
+    @patch("adb_mcp.tools.device.adb_exec", return_value="failed to connect")
+    def test_manual_host_no_serial_on_failure(self, mock_exec):
+        device_connect(host="192.168.1.10")
+        assert get_device_serial() is None


### PR DESCRIPTION
## Summary

- **Deduplicate mDNS results** in `device_connect()` by IP address, so the same physical device discovered under multiple service names only gets one connection
- **Store and use device serial** (`-s <serial>`) in all `adb_exec()` / `adb_exec_binary()` calls, so commands work even when multiple connections exist
- Added tests for deduplication, serial targeting, and connect behavior

Fixes #1

## Test plan
- [x] All 40 tests pass (8 new tests added)
- [x] `_deduplicate_devices()` correctly filters duplicate IPs
- [x] `device_connect()` stores serial on successful connection
- [x] `adb_exec()` and `adb_exec_binary()` include `-s <serial>` when set
- [x] Serial is not set when connection fails