### PR TITLE
Add install_app tool for installing APKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Add to your Claude Code settings (`~/.claude/settings.json` under `mcpServers`),
 | `input_text` | Type text into the focused field |
 | `press_key` | Press a key (back, home, enter, etc.) |
 | `launch_app` | Launch an app by package name |
+| `install_app` | Install an APK from the host machine onto the device |
 | `read_logs` | Read logcat output with optional filtering |
 | `shell` | Run an arbitrary adb shell command |
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add to your Claude Code settings (`~/.claude/settings.json` under `mcpServers`),
 | `input_text` | Type text into the focused field |
 | `press_key` | Press a key (back, home, enter, etc.) |
 | `launch_app` | Launch an app by package name |
-| `install_app` | Install an APK from the host machine onto the device |
+| `install_app` | Install an APK from the host machine onto the device (supports `reinstall` flag to keep data) |
 | `read_logs` | Read logcat output with optional filtering |
 | `shell` | Run an arbitrary adb shell command |
 

--- a/src/adb_mcp/server.py
+++ b/src/adb_mcp/server.py
@@ -37,7 +37,8 @@ volume_down, power, or menu.
 
 ## Other tools
 - `launch_app(package)` — launch an app (e.g., "com.android.settings").
-- `install_app(apk_path)` — install an APK from the host machine onto the device.
+- `install_app(apk_path, reinstall)` — install an APK from the host machine onto the \
+device. Set reinstall=True to replace an existing install while keeping its data.
 - `read_logs(filter, lines)` — read logcat output, optionally filtered.
 - `shell(command)` — run any adb shell command as an escape hatch.
 

--- a/src/adb_mcp/server.py
+++ b/src/adb_mcp/server.py
@@ -37,6 +37,7 @@ volume_down, power, or menu.
 
 ## Other tools
 - `launch_app(package)` — launch an app (e.g., "com.android.settings").
+- `install_app(apk_path)` — install an APK from the host machine onto the device.
 - `read_logs(filter, lines)` — read logcat output, optionally filtered.
 - `shell(command)` — run any adb shell command as an escape hatch.
 
@@ -121,6 +122,13 @@ def press_key(key: str) -> str:
 def launch_app(package: str) -> str:
     """Launch an app by package name (e.g. com.android.settings)."""
     return app.launch_app(package)
+
+
+@mcp.tool()
+def install_app(apk_path: str, reinstall: bool = False) -> str:
+    """Install an APK file from the host machine onto the device.
+    Set reinstall=True to replace an existing installation while keeping data."""
+    return app.install_app(apk_path, reinstall)
 
 
 @mcp.tool()

--- a/src/adb_mcp/tools/app.py
+++ b/src/adb_mcp/tools/app.py
@@ -4,3 +4,11 @@ from adb_mcp.adb import adb_exec
 def launch_app(package: str) -> str:
     return adb_exec("shell", "monkey", "-p", package,
                      "-c", "android.intent.category.LAUNCHER", "1")
+
+
+def install_app(apk_path: str, reinstall: bool = False) -> str:
+    args = ["install"]
+    if reinstall:
+        args.append("-r")
+    args.append(apk_path)
+    return adb_exec(*args, timeout=120)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,6 +5,7 @@ from adb_mcp.tools.input import _escape_text, press_key
 from adb_mcp.tools.app import launch_app
 from adb_mcp.tools.logs import read_logs
 from adb_mcp.tools.device import device_connect, _deduplicate_devices
+from adb_mcp.tools.app import install_app
 
 
 class TestEscapeText:
@@ -74,6 +75,20 @@ class TestReadLogs:
         read_logs(lines=100)
         args = mock_exec.call_args[0]
         assert "100" in args
+
+
+class TestInstallApp:
+    @patch("adb_mcp.tools.app.adb_exec", return_value="Success")
+    def test_install(self, mock_exec):
+        result = install_app("/tmp/app.apk")
+        mock_exec.assert_called_once_with("install", "/tmp/app.apk", timeout=120)
+        assert "Success" in result
+
+    @patch("adb_mcp.tools.app.adb_exec", return_value="Success")
+    def test_reinstall(self, mock_exec):
+        result = install_app("/tmp/app.apk", reinstall=True)
+        mock_exec.assert_called_once_with("install", "-r", "/tmp/app.apk", timeout=120)
+        assert "Success" in result
 
 
 class TestDeduplicateDevices:


### PR DESCRIPTION
## Summary

- Add `install_app(apk_path, reinstall)` tool that runs `adb install` to install an APK from the host machine onto the device
- Supports `reinstall=True` flag (`-r`) to replace existing installs while keeping data
- Updated MCP instructions and README with the new tool

## Test plan
- [x] `test_install` — verifies `adb install <path>` is called
- [x] `test_reinstall` — verifies `-r` flag is passed when `reinstall=True`
- [x] All 42 tests pass