### PR TITLE
Fix ui_tree XML parse error on some devices

### DIFF
--- a/src/adb_mcp/tools/screen.py
+++ b/src/adb_mcp/tools/screen.py
@@ -27,6 +27,8 @@ def screenshot(max_width: int = 540) -> tuple[str, str]:
 
 
 def ui_tree(simplified: bool = True) -> str:
-    xml_output = adb_exec("shell", "uiautomator", "dump", "/dev/tty", timeout=15)
+    dump_path = "/sdcard/window_dump.xml"
+    adb_exec("shell", "uiautomator", "dump", dump_path, timeout=15)
+    xml_output = adb_exec("shell", "cat", dump_path, timeout=5)
     parsed = parse_ui_tree(xml_output, simplified=simplified)
     return json.dumps(parsed, indent=2)


### PR DESCRIPTION
## Summary
- `ui_tree()` failed with `syntax error: line 1, column 0` on some devices (e.g. Samsung) because `uiautomator dump /dev/tty` doesn't reliably output XML to stdout
- Changed to dump to a file (`/sdcard/window_dump.xml`) and read it back with `cat`, which works across all devices

Fixes #4

## Test plan
- [x] Existing `test_ui_tree.py` tests pass (parser logic unchanged)
- [ ] Manual: call `ui_tree()` on a Samsung device over wireless debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)