### PR TITLE
Add local emulator and USB device support

### DIFF
--- a/src/adb_mcp/server.py
+++ b/src/adb_mcp/server.py
@@ -8,12 +8,13 @@ mcp = FastMCP(
 You control an Android device via adb over WiFi.
 
 ## Connection workflow (must be done first)
-1. **First-time pairing:** The user opens Settings > Developer options > Wireless \
-debugging > "Pair device with pairing code" on their phone, then gives you the \
-6-digit code. Call `device_pair(code="123456")`. The device is discovered \
-automatically via mDNS — you do NOT need host/port.
-2. **Connect:** Call `device_connect()` each session. Auto-discovers paired devices \
-on the network. No arguments needed.
+1. **First-time pairing (physical device only):** The user opens Settings > \
+Developer options > Wireless debugging > "Pair device with pairing code" on their \
+phone, then gives you the 6-digit code. Call `device_pair(code="123456")`. The \
+device is discovered automatically via mDNS — you do NOT need host/port.
+2. **Connect:** Call `device_connect()` each session. It auto-detects local \
+emulators and USB devices first, then falls back to mDNS network discovery for \
+wireless devices. No arguments needed.
 3. **Verify:** Call `device_status()` to confirm the device is online.
 
 ## Interacting with the screen
@@ -43,11 +44,11 @@ device. Set reinstall=True to replace an existing install while keeping its data
 - `shell(command)` — run any adb shell command as an escape hatch.
 
 ## Tips
-- Auto-discovery works on macOS. On Linux, the user must provide host and \
-port manually (shown on the wireless debugging screen on the phone).
-- If device_connect() finds nothing, ask the user to check that wireless \
-debugging is enabled and the phone is on the same WiFi network. If on \
-Linux, ask for the IP and port.
+- device_connect() detects local emulators automatically — no pairing needed.
+- Auto-discovery for wireless devices works on macOS. On Linux, the user \
+must provide host and port manually.
+- If device_connect() finds nothing, ask the user to check that either a \
+local emulator is running or wireless debugging is enabled on their phone.
 - Screenshots are downscaled to 540px wide by default to save tokens. Use \
 max_width to adjust if needed.
 - ui_tree with simplified=True (default) prunes empty containers. Use \
@@ -66,8 +67,9 @@ def device_pair(code: str, host: str | None = None, port: int | None = None) -> 
 
 @mcp.tool()
 def device_connect(host: str | None = None, port: int | None = None) -> str:
-    """Connect to a device over WiFi debugging. Automatically discovers
-    devices on the network. Provide host/port only as a manual override."""
+    """Connect to a device. Automatically detects local emulators and USB
+    devices first, then falls back to network discovery for wireless devices.
+    Provide host/port only as a manual override."""
     return device.device_connect(host, port)
 
 

--- a/src/adb_mcp/tools/device.py
+++ b/src/adb_mcp/tools/device.py
@@ -1,4 +1,4 @@
-from adb_mcp.adb import adb_exec, set_device_serial
+from adb_mcp.adb import adb_exec, set_device_serial, get_device_serial
 from adb_mcp.discovery import discover_pairing_devices, discover_connect_devices
 
 
@@ -36,6 +36,23 @@ def _deduplicate_devices(devices: list[dict]) -> list[dict]:
     return list(seen.values())
 
 
+def _find_local_devices() -> list[dict]:
+    """Check `adb devices` for already-connected devices (e.g. local emulators)."""
+    output = adb_exec("devices", "-l")
+    devices = []
+    for line in output.splitlines():
+        if "\tdevice" not in line:
+            continue
+        serial = line.split("\t")[0]
+        model = ""
+        for part in line.split():
+            if part.startswith("model:"):
+                model = part.split(":", 1)[1]
+                break
+        devices.append({"serial": serial, "model": model or serial})
+    return devices
+
+
 def device_connect(host: str | None = None, port: int | None = None) -> str:
     if host:
         serial = f"{host}:{port or 5555}"
@@ -44,11 +61,32 @@ def device_connect(host: str | None = None, port: int | None = None) -> str:
             set_device_serial(serial)
         return result
 
+    # Check for already-connected local devices (emulators, USB)
+    local = _find_local_devices()
+    if local:
+        # If we already have a selected device that's still connected, keep it
+        current = get_device_serial()
+        if current and any(d["serial"] == current for d in local):
+            return f"Already connected to {current}"
+
+        # Use the first available local device
+        chosen = local[0]
+        set_device_serial(chosen["serial"])
+        if len(local) == 1:
+            return f"Connected to {chosen['model']} ({chosen['serial']})"
+        lines = [f"Found {len(local)} local devices, using {chosen['model']} ({chosen['serial']}):"]
+        for d in local:
+            marker = " (selected)" if d["serial"] == chosen["serial"] else ""
+            lines.append(f"  {d['model']} ({d['serial']}){marker}")
+        return "\n".join(lines)
+
+    # Fall back to mDNS network discovery
     devices = discover_connect_devices(timeout=5.0)
     if not devices:
         return (
-            "No devices found on the network. Make sure wireless debugging "
-            "is enabled on your phone and it's on the same network."
+            "No devices found. Make sure either:\n"
+            "- A local emulator is running, or\n"
+            "- Wireless debugging is enabled on your phone and it's on the same network."
         )
 
     devices = _deduplicate_devices(devices)


### PR DESCRIPTION
## Summary
- `device_connect()` now detects local emulators and USB devices via `adb devices` before falling back to mDNS network discovery
- Updated server instructions and docstrings to reflect emulator support
- No pairing needed for local emulators — they're picked up automatically

## Test plan
- [ ] Start a local Android emulator, call `device_connect()` — should detect it
- [ ] With no emulator and no wireless device, verify the updated error message
- [ ] With a physical wireless device, verify mDNS fallback still works
- [ ] With multiple local devices, verify the first is selected and all are listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)