### PR TITLE
Fix ui_tree XML parsing error

### DIFF
--- a/src/adb_mcp/tools/screen.py
+++ b/src/adb_mcp/tools/screen.py
@@ -27,6 +27,6 @@ def screenshot(max_width: int = 540) -> tuple[str, str]:
 
 
 def ui_tree(simplified: bool = True) -> str:
-    xml_output = adb_exec("shell", "uiautomator", "dump", "/dev/tty", timeout=15)
+    xml_output = adb_exec("exec-out", "uiautomator", "dump", "/dev/tty", timeout=15)
     parsed = parse_ui_tree(xml_output, simplified=simplified)
     return json.dumps(parsed, indent=2)


### PR DESCRIPTION
## Summary
- Fix `ui_tree` failing with `syntax error: line 1, column 0` by changing `adb shell` to `adb exec-out`
- `adb shell uiautomator dump /dev/tty` writes XML to the device's TTY, not to the captured stdout pipe, so the XML parser receives no XML content
- `adb exec-out` correctly pipes the output back to the subprocess
- Also includes emulator/USB device support for `device_connect`

## Test plan
- [ ] Run `ui_tree()` against a connected device and verify it returns valid JSON
- [ ] Run `ui_tree(simplified=False)` to verify full hierarchy works too