### PR TITLE
Fix ui_tree: use exec-out instead of temp file

### DIFF
--- a/src/adb_mcp/tools/screen.py
+++ b/src/adb_mcp/tools/screen.py
@@ -27,8 +27,6 @@ def screenshot(max_width: int = 540) -> tuple[str, str]:
 
 
 def ui_tree(simplified: bool = True) -> str:
-    dump_path = "/sdcard/window_dump.xml"
-    adb_exec("shell", "uiautomator", "dump", dump_path, timeout=15)
-    xml_output = adb_exec("shell", "cat", dump_path, timeout=5)
+    xml_output = adb_exec("exec-out", "uiautomator", "dump", "/dev/tty", timeout=15)
     parsed = parse_ui_tree(xml_output, simplified=simplified)
     return json.dumps(parsed, indent=2)


### PR DESCRIPTION
## Summary
- Replace the file-based `uiautomator dump` approach with `exec-out uiautomator dump /dev/tty`
- The previous fix (#5) dumped to `/sdcard/window_dump.xml` then read it back with `cat`, which had issues:
  - Temp file is never cleaned up
  - If the dump fails, `cat` silently reads a stale file from a previous call
  - Extra adb round-trip adds unnecessary latency
- `exec-out` captures the XML directly via stdout in a single command

## Test plan
- [ ] Run `ui_tree()` against a connected device and verify valid JSON is returned
- [ ] Run `ui_tree(simplified=False)` to verify full hierarchy works
- [ ] Confirm no `/sdcard/window_dump.xml` is created on the device