### PR TITLE
Fix list_devices() returning empty when devices are connected

### DIFF
--- a/src/adb_mcp/tools/device.py
+++ b/src/adb_mcp/tools/device.py
@@ -41,11 +41,15 @@ def _find_local_devices() -> list[dict]:
     output = adb_exec("devices", "-l")
     devices = []
     for line in output.splitlines():
-        if "\tdevice" not in line:
+        # Skip header and empty lines
+        if not line.strip() or line.startswith("List of"):
             continue
-        serial = line.split("\t")[0]
+        parts = line.split()
+        if len(parts) < 2 or parts[1] != "device":
+            continue
+        serial = parts[0]
         model = ""
-        for part in line.split():
+        for part in parts:
             if part.startswith("model:"):
                 model = part.split(":", 1)[1]
                 break

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -121,6 +121,20 @@ class TestListDevices:
         assert devices[0]["serial"] == "emulator-5554"
         assert devices[1]["serial"] == "192.168.1.10:5555"
 
+    @patch("adb_mcp.tools.device.adb_exec", return_value="List of devices attached\nemulator-5554          device product:sdk_phone model:sdk_phone transport_id:1\n192.168.1.10:5555      device product:redfin model:Pixel_5 transport_id:2")
+    def test_returns_all_devices_space_separated(self, mock_exec):
+        devices = list_devices()
+        assert len(devices) == 2
+        assert devices[0]["serial"] == "emulator-5554"
+        assert devices[0]["model"] == "sdk_phone"
+        assert devices[1]["serial"] == "192.168.1.10:5555"
+        assert devices[1]["model"] == "Pixel_5"
+
+    @patch("adb_mcp.tools.device.adb_exec", return_value="List of devices attached\nemulator-5554          unauthorized transport_id:1")
+    def test_skips_unauthorized_devices(self, mock_exec):
+        devices = list_devices()
+        assert len(devices) == 0
+
     @patch("adb_mcp.tools.device.adb_exec", return_value="List of devices attached\n")
     def test_returns_empty_when_no_devices(self, mock_exec):
         assert list_devices() == []


### PR DESCRIPTION
## Summary
- Fixed `_find_local_devices()` parser that relied on a literal tab character (`\tdevice`) to identify device lines in `adb devices -l` output
- Real adb output often uses spaces for alignment, causing the parser to silently return an empty list
- Switched to whitespace-agnostic splitting (`line.split()`) so both tab-separated and space-separated formats are handled correctly
- This fixes `list_devices()` and `set_active_device()` which both depend on `_find_local_devices()`

Closes #11

## Test plan
- [x] Existing tests still pass (tab-separated format)
- [x] New test for space-separated format (`test_returns_all_devices_space_separated`)
- [x] New test for unauthorized device filtering (`test_skips_unauthorized_devices`)
- [ ] Manual verification with real emulator + physical device