### PR TITLE
Add ADB_DEVICE_SERIAL env var to pin server to a device

### DIFF
--- a/src/adb_mcp/adb.py
+++ b/src/adb_mcp/adb.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 
@@ -14,7 +15,7 @@ def _find_adb() -> str:
 
 ADB = _find_adb()
 
-_device_serial: str | None = None
+_device_serial: str | None = os.environ.get("ADB_DEVICE_SERIAL")
 
 
 def set_device_serial(serial: str | None) -> None:

--- a/src/adb_mcp/server.py
+++ b/src/adb_mcp/server.py
@@ -49,6 +49,12 @@ device. Set reinstall=True to replace an existing install while keeping its data
 - Call `list_devices()` to see all connected devices and which one is active.
 - Call `set_active_device(serial)` to switch which device receives commands.
 
+## Pinning a device
+- Set the `ADB_DEVICE_SERIAL` environment variable to pin this server instance \
+to a specific device (e.g., `ADB_DEVICE_SERIAL=emulator-5554`).
+- When pinned, `device_connect()` only connects to that device, preventing \
+multiple agents from accidentally sharing the same device.
+
 ## Tips
 - device_connect() detects local emulators automatically — no pairing needed.
 - Auto-discovery for wireless devices works on macOS. On Linux, the user \

--- a/src/adb_mcp/tools/device.py
+++ b/src/adb_mcp/tools/device.py
@@ -1,5 +1,9 @@
+import os
+
 from adb_mcp.adb import adb_exec, set_device_serial, get_device_serial
 from adb_mcp.discovery import discover_pairing_devices, discover_connect_devices
+
+_pinned_serial: str | None = os.environ.get("ADB_DEVICE_SERIAL")
 
 
 def device_pair(code: str, host: str | None = None, port: int | None = None) -> str:
@@ -58,6 +62,20 @@ def _find_local_devices() -> list[dict]:
 
 
 def device_connect(host: str | None = None, port: int | None = None) -> str:
+    # If pinned via ADB_DEVICE_SERIAL, verify the device is available
+    if _pinned_serial and not host:
+        devices = _find_local_devices()
+        if any(d["serial"] == _pinned_serial for d in devices):
+            model = next(
+                (d["model"] for d in devices if d["serial"] == _pinned_serial),
+                _pinned_serial,
+            )
+            return f"Connected to pinned device {model} ({_pinned_serial})"
+        return (
+            f"Pinned device '{_pinned_serial}' (from ADB_DEVICE_SERIAL) "
+            f"not found. Available: {', '.join(d['serial'] for d in devices) or 'none'}"
+        )
+
     if host:
         serial = f"{host}:{port or 5555}"
         result = adb_exec("connect", serial, timeout=15)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -210,3 +210,28 @@ class TestDeviceConnect:
         # Should keep existing selection, not reset to first
         assert get_device_serial() == "192.168.1.10:5555"
         assert "(active)" in result
+
+    @patch("adb_mcp.tools.device._pinned_serial", "emulator-5554")
+    @patch("adb_mcp.tools.device._find_local_devices", return_value=[
+        {"serial": "emulator-5554", "model": "sdk_phone"},
+        {"serial": "192.168.1.10:5555", "model": "Pixel_7"},
+    ])
+    def test_pinned_serial_connects_to_pinned_device(self, mock_find):
+        result = device_connect()
+        assert "pinned" in result
+        assert "emulator-5554" in result
+
+    @patch("adb_mcp.tools.device._pinned_serial", "emulator-5556")
+    @patch("adb_mcp.tools.device._find_local_devices", return_value=[
+        {"serial": "emulator-5554", "model": "sdk_phone"},
+    ])
+    def test_pinned_serial_reports_missing_device(self, mock_find):
+        result = device_connect()
+        assert "not found" in result
+        assert "emulator-5556" in result
+
+    @patch("adb_mcp.tools.device._pinned_serial", "emulator-5554")
+    @patch("adb_mcp.tools.device.adb_exec", return_value="connected to 192.168.1.10:5555")
+    def test_pinned_serial_ignored_with_manual_host(self, mock_exec):
+        result = device_connect(host="192.168.1.10", port=5555)
+        assert get_device_serial() == "192.168.1.10:5555"


### PR DESCRIPTION
## Summary
- Adds `ADB_DEVICE_SERIAL` environment variable support to pin an MCP server instance to a specific device
- When set, `device_connect()` skips auto-discovery and only connects to the pinned device
- Manual `host`/`port` overrides still work regardless of the pin
- Enables running multiple agents concurrently, each targeting a different emulator without interfering with each other

## Test plan
- [x] Pinned serial connects to the correct device
- [x] Reports error when pinned device is not found
- [x] Manual host/port override ignores the pin
- [x] All existing tests still pass (54 total)