### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adb-mcp"
-version = "0.3.0"
+version = "0.4.0"
 description = "MCP server for Android device interaction via adb"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.4.0 for release

## Changes since v0.3.0
- Fix `list_devices()` returning empty when devices are connected (#12)
- Add `ADB_DEVICE_SERIAL` env var to pin server to a specific device (#13)